### PR TITLE
updated expected json structure and partition naming

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/FlatTimestampPayload.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/FlatTimestampPayload.java
@@ -16,9 +16,20 @@
 
 package io.confluent.connect.s3.extensions;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
 public class FlatTimestampPayload implements UdxPayload {
   private String timestamp;
   private String id;
+
+  @JsonProperty("payload")
+  private void unpackNested(Map<String, Object> payload) {
+    // For timestamps of form: timestamp: '2021-05-07T06:06:30Z',
+    this.timestamp = (String) payload.get("timestamp");
+    this.id = (String) payload.get("id");
+  }
 
   public String getTimestamp() {
     return timestamp;
@@ -37,6 +48,6 @@ public class FlatTimestampPayload implements UdxPayload {
   }
 
   public String toString() {
-    return "OcpiPayload [ entityId: " + getId() + ", timestamp: " + getTimestamp() + " ]";
+    return "Payload [ entityId: " + getId() + ", timestamp: " + getTimestamp() + " ]";
   }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/NestedTimestampPayload.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/NestedTimestampPayload.java
@@ -25,10 +25,12 @@ public class NestedTimestampPayload implements UdxPayload {
   private String id;
 
   @SuppressWarnings("unchecked")
-  @JsonProperty("timestamp")
-  private void unpackNested(Map<String, Object> timestamp) {
+  @JsonProperty("payload")
+  private void unpackNested(Map<String, Object> payload) {
     // For timestamps of form: timestamp: { type: 'Property', value: '2021-05-07T06:06:30Z' },
-    this.timestamp = (String) timestamp.get("value");
+    this.id = (String) payload.get("id");
+    Map<String,String> timestamp = (Map<String,String>)payload.get("timestamp");
+    this.timestamp = timestamp.get("value");
   }
 
   public String getTimestamp() {
@@ -48,6 +50,6 @@ public class NestedTimestampPayload implements UdxPayload {
   }
 
   public String toString() {
-    return "OcpiPayload [ entityId: " + getId() + ", timestamp: " + getTimestamp() + " ]";
+    return "Payload [ entityId: " + getId() + ", timestamp: " + getTimestamp() + " ]";
   }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/UdxStreamPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/UdxStreamPartitioner.java
@@ -36,11 +36,11 @@ import java.util.UUID;
 public class UdxStreamPartitioner<T> extends DefaultPartitioner<T> {
   private static final Logger log = LoggerFactory.getLogger(UdxStreamPartitioner.class);
   private static final String PARTITION_FORMAT =
-          "streamUuid=%s/entityId=%s/%d-%02d/day=%02d/hour=%02d";
+          "stream_uuid=%s/entity_id=%s/year_month=%d-%02d/day=%02d/hour=%02d";
   private static final String INVALID_PAYLOAD_PARTITION_FORMAT =
-          "invalidIdOrTimestamp/streamUuid=%s";
+          "invalid_payloads/stream_uuid=%s";
   private static final String INVALID_TIMESTAMP_PARTITION_FORMAT =
-          "invalidIdOrTimestamp/streamUuid=%s/entityId=%s/%s";
+          "invalid_payloads/stream_uuid=%s/entity_id=%s/%s";
 
   @Override
   public void configure(Map<String, Object> config) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
@@ -33,7 +33,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
     // - Check that it has timestamp in the payload in the right format to be parsed (zulu time)
     // - Produce the correct path from the 'String encodePartition(SinkRecord sinkRecord)' function
 
-    private static final String UDX_PARTITION_FORMAT_FOR_INTS = "streamUuid=%s/entityId=%s/%d-%02d/day=%02d/hour=%02d";
+    private static final String UDX_PARTITION_FORMAT_FOR_INTS = "stream_uuid=%s/entity_id=%s/year_month=%d-%02d/day=%02d/hour=%02d";
 
     private SinkRecord generateUdxPayloadRecordNullKey(String streamUuid, String payload, Long timestamp) {
         Headers headers = new ConnectHeaders();
@@ -92,7 +92,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         // Create an OCPI location payload
         String payloadTimestamp = String.format("%d-%02d-%02dT%02d:12:34Z", YYYY, MM, DD, HH);
         String ocpiSessionPayload = String.format(
-                "{\"id\":\"%s\",\"countryCode\":\"GB\",\"partyId\":\"CKL\",\"type\":\"EVChargingSession\",\"evseId\":\"GB*CKL*7*1\",\"address\":{\"postalCode\":\"CV1 3AQ\",\"streetAddress\":\"Northumberland Road\",\"addressCountry\":\"GB\",\"addressLocality\":\"Coventry\"},\"totalKW\":1.019,\"location\":{\"type\":\"Point\",\"coordinates\":[-1.524266,52.411123]},\"provider\":\"CKL\",\"sessionId\":59,\"timestamp\":\"%s\",\"connectorId\":7,\"sessionDurationMins\":0.3,\"chargingDurationMins\":0.3,\"sessionStartTime\":\"2020-04-28T11:54:54Z\",\"sessionEndTime\":\"2020-04-28T11:55:09Z\",\"totalCost\":{\"exclVat\":1,\"inclVat\":1.2}}",
+                "{\"payload\":{\"id\":\"%s\",\"countryCode\":\"GB\",\"partyId\":\"CKL\",\"type\":\"EVChargingSession\",\"evseId\":\"GB*CKL*7*1\",\"address\":{\"postalCode\":\"CV1 3AQ\",\"streetAddress\":\"Northumberland Road\",\"addressCountry\":\"GB\",\"addressLocality\":\"Coventry\"},\"totalKW\":1.019,\"location\":{\"type\":\"Point\",\"coordinates\":[-1.524266,52.411123]},\"provider\":\"CKL\",\"sessionId\":59,\"timestamp\":\"%s\",\"connectorId\":7,\"sessionDurationMins\":0.3,\"chargingDurationMins\":0.3,\"sessionStartTime\":\"2020-04-28T11:54:54Z\",\"sessionEndTime\":\"2020-04-28T11:55:09Z\",\"totalCost\":{\"exclVat\":1,\"inclVat\":1.2}}}",
                 entityId,
                 payloadTimestamp
                 );
@@ -131,7 +131,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         long timestamp = new DateTime(YYYY, MM, DD, HH, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
         String payloadTimestamp = String.format("%d-%02d-%02dT%02d:12:34Z", YYYY, MM, DD, HH);
         String ocpiLocationPayload = String.format(
-                "{\"id\":\"%s\",\"type\":\"EVChargingStation\",\"status\":{\"type\":\"Property\",\"value\":\"AVAILABLE\"},\"address\":{\"type\":\"Property\",\"value\":{\"type\":\"PostalAddress\",\"postalCode\":\"N15 6BT\",\"streetAddress\":\"Grovelands Road\",\"addressCountry\":\"GBR\",\"addressLocality\":\"Haringey\"}},\"voltage\":{\"type\":\"Property\",\"value\":230},\"amperage\":{\"type\":\"Property\",\"value\":23},\"location\":{\"type\":\"GeoProperty\",\"value\":{\"type\":\"Point\",\"coordinates\":[-0.06414,51.578497]}},\"operator\":{\"type\":\"Property\",\"value\":\"char.gy\"},\"timestamp\":{\"type\":\"Property\",\"value\":\"%s\"},\"powerOutput\":{\"type\":\"Property\",\"value\":52.9},\"chargingType\":{\"type\":\"Property\",\"value\":\"rapid\"},\"dateModified\":{\"type\":\"Property\",\"value\":\"2021-05-07T06:06:30Z\"},\"socketNumber\":{\"type\":\"Property\",\"value\":1},\"commissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"decommissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"@context\":[\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld\"]}",
+                "{\"payload\":{\"id\":\"%s\",\"type\":\"EVChargingStation\",\"status\":{\"type\":\"Property\",\"value\":\"AVAILABLE\"},\"address\":{\"type\":\"Property\",\"value\":{\"type\":\"PostalAddress\",\"postalCode\":\"N15 6BT\",\"streetAddress\":\"Grovelands Road\",\"addressCountry\":\"GBR\",\"addressLocality\":\"Haringey\"}},\"voltage\":{\"type\":\"Property\",\"value\":230},\"amperage\":{\"type\":\"Property\",\"value\":23},\"location\":{\"type\":\"GeoProperty\",\"value\":{\"type\":\"Point\",\"coordinates\":[-0.06414,51.578497]}},\"operator\":{\"type\":\"Property\",\"value\":\"char.gy\"},\"timestamp\":{\"type\":\"Property\",\"value\":\"%s\"},\"powerOutput\":{\"type\":\"Property\",\"value\":52.9},\"chargingType\":{\"type\":\"Property\",\"value\":\"rapid\"},\"dateModified\":{\"type\":\"Property\",\"value\":\"2021-05-07T06:06:30Z\"},\"socketNumber\":{\"type\":\"Property\",\"value\":1},\"commissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"decommissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"@context\":[\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld\"]}}",
                 entityId,
                 payloadTimestamp
         );
@@ -174,7 +174,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         long payloadTimestampAsUnix = new DateTime(stringTimestampISO8601).getMillis();
         DateTime test = new DateTime(payloadTimestampAsUnix);
         String ocpiLocationPayload = String.format(
-                "{\"id\":\"%s\",\"type\":\"EVChargingStation\",\"status\":{\"type\":\"Property\",\"value\":\"AVAILABLE\"},\"address\":{\"type\":\"Property\",\"value\":{\"type\":\"PostalAddress\",\"postalCode\":\"N15 6BT\",\"streetAddress\":\"Grovelands Road\",\"addressCountry\":\"GBR\",\"addressLocality\":\"Haringey\"}},\"voltage\":{\"type\":\"Property\",\"value\":230},\"amperage\":{\"type\":\"Property\",\"value\":23},\"location\":{\"type\":\"GeoProperty\",\"value\":{\"type\":\"Point\",\"coordinates\":[-0.06414,51.578497]}},\"operator\":{\"type\":\"Property\",\"value\":\"char.gy\"},\"timestamp\":{\"type\":\"Property\",\"value\":\"%d\"},\"powerOutput\":{\"type\":\"Property\",\"value\":52.9},\"chargingType\":{\"type\":\"Property\",\"value\":\"rapid\"},\"dateModified\":{\"type\":\"Property\",\"value\":\"2021-05-07T06:06:30Z\"},\"socketNumber\":{\"type\":\"Property\",\"value\":1},\"commissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"decommissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"@context\":[\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld\"]}",
+                "{\"payload\":{\"id\":\"%s\",\"type\":\"EVChargingStation\",\"status\":{\"type\":\"Property\",\"value\":\"AVAILABLE\"},\"address\":{\"type\":\"Property\",\"value\":{\"type\":\"PostalAddress\",\"postalCode\":\"N15 6BT\",\"streetAddress\":\"Grovelands Road\",\"addressCountry\":\"GBR\",\"addressLocality\":\"Haringey\"}},\"voltage\":{\"type\":\"Property\",\"value\":230},\"amperage\":{\"type\":\"Property\",\"value\":23},\"location\":{\"type\":\"GeoProperty\",\"value\":{\"type\":\"Point\",\"coordinates\":[-0.06414,51.578497]}},\"operator\":{\"type\":\"Property\",\"value\":\"char.gy\"},\"timestamp\":{\"type\":\"Property\",\"value\":\"%d\"},\"powerOutput\":{\"type\":\"Property\",\"value\":52.9},\"chargingType\":{\"type\":\"Property\",\"value\":\"rapid\"},\"dateModified\":{\"type\":\"Property\",\"value\":\"2021-05-07T06:06:30Z\"},\"socketNumber\":{\"type\":\"Property\",\"value\":1},\"commissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"decommissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"@context\":[\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld\"]}}",
                 entityId,
                 payloadTimestampAsUnix
         );
@@ -218,7 +218,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
                 timestamp
         );
         String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
-        assertThat(encodedPartition, is(String.format("invalidIdOrTimestamp/streamUuid=%s", streamUuid)));
+        assertThat(encodedPartition, is(String.format("invalid_payloads/stream_uuid=%s", streamUuid)));
     }
 
     @Test
@@ -247,7 +247,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         );
 
         String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
-        assertThat(encodedPartition, is(String.format("invalidIdOrTimestamp/streamUuid=%s", streamUuidNotAUuid)));
+        assertThat(encodedPartition, is(String.format("invalid_payloads/stream_uuid=%s", streamUuidNotAUuid)));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         );
 
         String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
-        assertThat(encodedPartition, is(String.format("invalidIdOrTimestamp/streamUuid=noStreamIdFound")));
+        assertThat(encodedPartition, is(String.format("invalid_payloads/stream_uuid=noStreamIdFound")));
     }
 
     @Test
@@ -297,7 +297,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         long timestamp = new DateTime(YYYY, MM, DD, HH, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
         String payloadTimestamp = String.format("hey hey - %d-%02d-%02dla-la-la-la-la%02d:12:34Z", YYYY, MM, DD, HH);
         String ocpiLocationPayload = String.format(
-                "{\"id\":\"%s\",\"type\":\"EVChargingStation\",\"status\":{\"type\":\"Property\",\"value\":\"AVAILABLE\"},\"address\":{\"type\":\"Property\",\"value\":{\"type\":\"PostalAddress\",\"postalCode\":\"N15 6BT\",\"streetAddress\":\"Grovelands Road\",\"addressCountry\":\"GBR\",\"addressLocality\":\"Haringey\"}},\"voltage\":{\"type\":\"Property\",\"value\":230},\"amperage\":{\"type\":\"Property\",\"value\":23},\"location\":{\"type\":\"GeoProperty\",\"value\":{\"type\":\"Point\",\"coordinates\":[-0.06414,51.578497]}},\"operator\":{\"type\":\"Property\",\"value\":\"char.gy\"},\"timestamp\":{\"type\":\"Property\",\"value\":\"%s\"},\"powerOutput\":{\"type\":\"Property\",\"value\":52.9},\"chargingType\":{\"type\":\"Property\",\"value\":\"rapid\"},\"dateModified\":{\"type\":\"Property\",\"value\":\"2021-05-07T06:06:30Z\"},\"socketNumber\":{\"type\":\"Property\",\"value\":1},\"commissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"decommissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"@context\":[\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld\"]}",
+                "{\"payload\":{\"id\":\"%s\",\"type\":\"EVChargingStation\",\"status\":{\"type\":\"Property\",\"value\":\"AVAILABLE\"},\"address\":{\"type\":\"Property\",\"value\":{\"type\":\"PostalAddress\",\"postalCode\":\"N15 6BT\",\"streetAddress\":\"Grovelands Road\",\"addressCountry\":\"GBR\",\"addressLocality\":\"Haringey\"}},\"voltage\":{\"type\":\"Property\",\"value\":230},\"amperage\":{\"type\":\"Property\",\"value\":23},\"location\":{\"type\":\"GeoProperty\",\"value\":{\"type\":\"Point\",\"coordinates\":[-0.06414,51.578497]}},\"operator\":{\"type\":\"Property\",\"value\":\"char.gy\"},\"timestamp\":{\"type\":\"Property\",\"value\":\"%s\"},\"powerOutput\":{\"type\":\"Property\",\"value\":52.9},\"chargingType\":{\"type\":\"Property\",\"value\":\"rapid\"},\"dateModified\":{\"type\":\"Property\",\"value\":\"2021-05-07T06:06:30Z\"},\"socketNumber\":{\"type\":\"Property\",\"value\":1},\"commissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"decommissionDate\":{\"type\":\"Property\",\"value\":\"\"},\"@context\":[\"https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld\",\"https://raw.githubusercontent.com/smart-data-models/dataModel.Transportation/master/context.jsonld\"]}}",
                 entityId,
                 payloadTimestamp
         );
@@ -309,6 +309,6 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         );
 
         String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
-        assertThat(encodedPartition, is(String.format("invalidIdOrTimestamp/streamUuid=%s/entityId=%s/%s", streamUuid, entityId, payloadTimestamp)));
+        assertThat(encodedPartition, is(String.format("invalid_payloads/stream_uuid=%s/entity_id=%s/%s", streamUuid, entityId, payloadTimestamp)));
     }
 }


### PR DESCRIPTION
In this PR I have updated the partitioner to expect json objects with the following structure:

{payload: {...}}

This means the schema in Glue and Athena should be more generic across all streams with column names being:
stream_uuid
entity_id
year_month
day
hour
payload

This means we will need to update the code in Storage microservice to wrap each payload in the { payload: {} } structure before sending into the historic topic.

I have also updated the partition naming so the S3 partition structure is now:

```
topics/<topic_name>/stream_uuid=<stream uuid>/entity_id=<entity id>/year_month=<YYYY_MM>/day=<day>/hour=<hour>
```

This removes the mixing of upper and lower case which can cause problems when creating column names later down the line. I have also added an explicit column name 'year_month'
