### PR TITLE
extra error checking and test

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/UdxStreamPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/UdxStreamPartitioner.java
@@ -183,7 +183,7 @@ public class UdxStreamPartitioner<T> extends DefaultPartitioner<T> {
 
     UdxPayload udxPayload = parseJsonStringToKnownClass(jsonStringValue);
 
-    if (udxPayload.getId() == null || udxPayload.getTimestamp() == null) {
+    if (udxPayload == null || udxPayload.getId() == null || udxPayload.getTimestamp() == null) {
       log.warn("No UdxPayload mapping found, sending payload to non stream uuid partition...");
       String msg = "Could not map this payload to a defined UdxPayload class";
       // At this point, it might be a good idea to see if we can still parse the timestamp.

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
@@ -222,6 +222,34 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
     }
 
     @Test
+    public void testCannotParseNonJsonPayload() {
+        // Top level config
+        Map<String, Object> config = new HashMap<>();
+        config.put(StorageCommonConfig.DIRECTORY_DELIM_CONFIG, StorageCommonConfig.DIRECTORY_DELIM_DEFAULT);
+
+        // Configure the partitioner
+        UdxStreamPartitioner<String> partitioner = new UdxStreamPartitioner<>();
+        partitioner.configure(config);
+
+        String streamUuid = "1e962902-65ae-4346-bb8d-d2206d6dc852";
+
+        String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
+        int YYYY = 2022;
+        int MM = 6;
+        int DD = 9;
+        int HH = 7;
+        long timestamp = new DateTime(YYYY, MM, DD, HH, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        String ocpiLocationPayload = "{not={valid=atAll}}";
+        SinkRecord ocpiSessionRecord = generateUdxPayloadRecordNullKey(
+                streamUuid,
+                ocpiLocationPayload,
+                timestamp
+        );
+        String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
+        assertThat(encodedPartition, is(String.format("invalid_payloads/stream_uuid=%s", streamUuid)));
+    }
+
+    @Test
     public void testNoValidUuidInHeaders() {
         // Top level config
         Map<String, Object> config = new HashMap<>();


### PR DESCRIPTION
If the payload is not JSON the partitioner throws a nullPointerException when it tries to check the udxPayload.getId() or udxPayload.getTime()

I added an extra check on udxPayload == null before this, and an extra unit test to check non JSON payloads are handled correctly and no errors are thrown