### PR TITLE
Udx 1298 update msk connect connector to remove any special characters from entity

### DIFF
--- a/bin/build_zip_and_copy_to_s3.sh
+++ b/bin/build_zip_and_copy_to_s3.sh
@@ -6,4 +6,4 @@ S3_PATH="s3://udx-$ENV-msk-connectors/$OUTPUT_ZIP_NAME"
 
 mvn clean package -DskipTests && \
 echo "Copying ZIP archived build to S3 to path: $S3_PATH" && \
-aws s3 cp kafka-connect-s3/target/components/packages/confluentinc-kafka-connect-s3-10.0.8.zip s3://udx-$ENV-msk-connectors/$OUTPUT_ZIP_NAME --profile udx-$ENV
+aws s3 cp kafka-connect-s3/target/components/packages/confluentinc-kafka-connect-s3-10.1.0-SNAPSHOT.zip s3://udx-$ENV-msk-connectors/$OUTPUT_ZIP_NAME --profile udx-$ENV

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/UdxStreamPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/extensions/UdxStreamPartitioner.java
@@ -211,8 +211,13 @@ public class UdxStreamPartitioner<T> extends DefaultPartitioner<T> {
 
     log.info("Mapping record value into object...");
     log.info(udxPayload.toString());
-    String entityId = udxPayload.getId();
+    String entityIdRaw = udxPayload.getId();
     String timestamp = udxPayload.getTimestamp();
+
+    // Replace all disallowed characters from entityId as these
+    // special characters can't be part of partition path.
+    String entityId = entityIdRaw.replaceAll("[^A-Za-z0-9!\\-_\\.*'()]", "_");
+    log.info("Original entityId = " + entityIdRaw + ", Transformed entityId = " + entityId);
 
     try {
       DateTime parsedTimestamp = parseTimestampFromPayload(timestamp);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
@@ -162,8 +162,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         partitioner.configure(config);
 
         String streamUuid = "1e962902-65ae-4346-bb8d-d2206d6dc852";
-        String entityId = "entity-1234:5678;/$&9";
-        String expectedEntityId = "entity-1234_5678____9";
+        String entityId = "entity-1234";
 
         String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
         int YYYY = 2022;
@@ -191,7 +190,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
 
         // Assert that the filepath is correct
-        String expectedPath = String.format(UDX_PARTITION_FORMAT_FOR_INTS, streamUuid, expectedEntityId, YYYY, MM, DD, HH);
+        String expectedPath = String.format(UDX_PARTITION_FORMAT_FOR_INTS, streamUuid, entityId, YYYY, MM, DD, HH);
         assertThat(encodedPartition, is(expectedPath));
     }
 
@@ -212,13 +211,13 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         int HH = 7;
         long timestamp = new DateTime(YYYY, MM, DD, HH, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
         String streamUuid = "1e962902-65ae-4346-bb8d-d2206d6dc852";
-        String entityId = "entity-1234";
-        // timestamp format: "2021-08-31T17:24:13Z";
-        // Create an OCPI location payload
+
+        String entityId = "entity-1234:5678;/$&9";
+        String expectedEntityId = "entity-1234_5678____9";
 
         String payloadTimestamp = String.format("%d-%02d-%02dT%02d:12:34Z", YYYY, MM, DD, HH);
         String ocpiSessionPayload = String.format(
-          "{\"id\":\"%s\",\"countryCode\":\"GB\",\"partyId\":\"CKL\",\"type\":\"EVChargingSession\",\"evseId\":\"GB*CKL*7*1\",\"address\":{\"postalCode\":\"CV1 3AQ\",\"streetAddress\":\"Northumberland Road\",\"addressCountry\":\"GB\",\"addressLocality\":\"Coventry\"},\"totalKW\":1.019,\"location\":{\"type\":\"Point\",\"coordinates\":[-1.524266,52.411123]},\"provider\":\"CKL\",\"sessionId\":59,\"timestamp\":\"%s\",\"connectorId\":7,\"sessionDurationMins\":0.3,\"chargingDurationMins\":0.3,\"sessionStartTime\":\"2020-04-28T11:54:54Z\",\"sessionEndTime\":\"2020-04-28T11:55:09Z\",\"totalCost\":{\"exclVat\":1,\"inclVat\":1.2}}",
+          "{\"payload\":\"{\\\"id\\\":\\\"%s\\\",\\\"timestamp\\\":\\\"%s\\\"}\"}",
           entityId,
           payloadTimestamp
         );
@@ -233,7 +232,7 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
 
         // Assert that the filepath is correct
-        String expectedPath = String.format(UDX_PARTITION_FORMAT_FOR_INTS, streamUuid, entityId, YYYY, MM, DD, HH);
+        String expectedPath = String.format(UDX_PARTITION_FORMAT_FOR_INTS, streamUuid, expectedEntityId, YYYY, MM, DD, HH);
         assertThat(encodedPartition, is(expectedPath));
     }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/extensions/UdxStreamPartitionerTest.java
@@ -210,7 +210,8 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         partitioner.configure(config);
 
         String streamUuid = "1e962902-65ae-4346-bb8d-d2206d6dc852";
-        String entityId = "entity-1234";
+        String entityId = "entity-1234:5678;/$&9";
+        String expectedEntityId = "entity-1234_5678____9";
 
         String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
         int YYYY = 2022;
@@ -231,6 +232,48 @@ public class UdxStreamPartitionerTest extends StorageSinkTestBase {
         SinkRecord ocpiSessionRecord = generateUdxPayloadRecordNullKey(
                 streamUuid,
                 ocpiLocationPayload,
+                timestamp
+        );
+
+        // Run the partitioner
+        String encodedPartition = partitioner.encodePartition(ocpiSessionRecord);
+
+        // Assert that the filepath is correct
+        String expectedPath = String.format(UDX_PARTITION_FORMAT_FOR_INTS, streamUuid, expectedEntityId, YYYY, MM, DD, HH);
+        assertThat(encodedPartition, is(expectedPath));
+    }
+
+    @Test
+    public void testProducesPathFromSpecialCharacterEntityId() {
+        // Top level config
+        Map<String, Object> config = new HashMap<>();
+        config.put(StorageCommonConfig.DIRECTORY_DELIM_CONFIG, StorageCommonConfig.DIRECTORY_DELIM_DEFAULT);
+
+        // Configure the partitioner
+        UdxStreamPartitioner<String> partitioner = new UdxStreamPartitioner<>();
+        partitioner.configure(config);
+
+        String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
+        int YYYY = 2022;
+        int MM = 6;
+        int DD = 9;
+        int HH = 7;
+        long timestamp = new DateTime(YYYY, MM, DD, HH, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        String streamUuid = "1e962902-65ae-4346-bb8d-d2206d6dc852";
+        String entityId = "entity-1234";
+        // timestamp format: "2021-08-31T17:24:13Z";
+        // Create an OCPI location payload
+
+        String payloadTimestamp = String.format("%d-%02d-%02dT%02d:12:34Z", YYYY, MM, DD, HH);
+        String ocpiSessionPayload = String.format(
+          "{\"id\":\"%s\",\"countryCode\":\"GB\",\"partyId\":\"CKL\",\"type\":\"EVChargingSession\",\"evseId\":\"GB*CKL*7*1\",\"address\":{\"postalCode\":\"CV1 3AQ\",\"streetAddress\":\"Northumberland Road\",\"addressCountry\":\"GB\",\"addressLocality\":\"Coventry\"},\"totalKW\":1.019,\"location\":{\"type\":\"Point\",\"coordinates\":[-1.524266,52.411123]},\"provider\":\"CKL\",\"sessionId\":59,\"timestamp\":\"%s\",\"connectorId\":7,\"sessionDurationMins\":0.3,\"chargingDurationMins\":0.3,\"sessionStartTime\":\"2020-04-28T11:54:54Z\",\"sessionEndTime\":\"2020-04-28T11:55:09Z\",\"totalCost\":{\"exclVat\":1,\"inclVat\":1.2}}",
+          entityId,
+          payloadTimestamp
+        );
+
+        SinkRecord ocpiSessionRecord = generateUdxPayloadRecordNullKey(
+                streamUuid,
+                ocpiSessionPayload,
                 timestamp
         );
 


### PR DESCRIPTION
Added lines to replace all disallowed characters from the entity_id.
This is to ensure that only allowed characters are used in the object key.

Replaces all disallowed characters with an '_'